### PR TITLE
Avoid duplication vote

### DIFF
--- a/helpers/requests.js
+++ b/helpers/requests.js
@@ -142,7 +142,8 @@ async function voteQuery(bot, msg) {
       request.voters_ban = request.voters_ban.filter(
         (arrayVoter) => !arrayVoter._id.equals(voter._id)
       )
-      request.voters_noban.push(voter)
+      request.update({ 'voters_noban._id': { $ne: voter._id } },
+        { $addToSet: { voters_noban: voter } });
     } else {
       const alreadyThere = _.find(request.voters_ban, (arrayVoter) =>
         arrayVoter._id.equals(voter._id)
@@ -159,7 +160,8 @@ async function voteQuery(bot, msg) {
       request.voters_noban = request.voters_noban.filter(
         (arrayVoter) => !arrayVoter._id.equals(voter._id)
       )
-      request.voters_ban.push(voter)
+      request.update({ 'voters_ban._id': { $ne: voter._id } },
+        { $addToSet: { voters_ban: voter } });
     }
     request = await request.save()
     await updateMessage(bot, request)


### PR DESCRIPTION
Sometime when you couple of times click for voting - your vote could be duplicated. Current logic doesn't check voter for unique. I added check for this. Also I have suspicious that should change checking from _id to id in all cases, because by mongo logic '_id' and 'id' are different fields an there could be potential collision. By this reason PR now in draft.